### PR TITLE
Added CopyLocalLockFileAssemblies

### DIFF
--- a/PSMSI.csproj
+++ b/PSMSI.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>False</AutoGenerateBindingRedirects>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added `CopyLocalLockFileAssemblies` to csproj to ensure necessary nuget dependencies are packaged correctly when building.

#8 